### PR TITLE
Fix search container alignment

### DIFF
--- a/client/src/StyleSheet/SearchBar.css
+++ b/client/src/StyleSheet/SearchBar.css
@@ -6,7 +6,8 @@
 .Search__field {
   display: flex;
   align-items: center;
-  margin-left: 540px;
+  margin-left: auto;
+  margin-right: auto;
   margin-top: 20px;
   padding: 10px;
   height: 30px;
@@ -17,16 +18,13 @@
 
 .Search__field > input {
   border: none;
-  margin-left: 20px;
 }
 .filters {
   margin-top: 10px;
-  margin-left: 29px;
 }
 .Search__text > h4 {
   font-weight: 900;
   font-size: 20px;
-  margin-left: 20px;
 }
 .SearchBar__links {
   display: flex;
@@ -45,78 +43,60 @@
   .Search__field {
     display: flex;
     align-items: center;
-    margin-left: 15rem;
     height: 30px;
   }
   .filters {
     margin-top: 10px;
-    margin-left: -5px;
   }
 
   .Search__text > h4 {
     font-weight: 900;
     font-size: 20px;
-    margin-left: -90px;
   }
 }
 @media only screen and (max-width: 700px) {
   .Search__field {
     display: flex;
     align-items: center;
-    margin-left: 200px;
     height: 30px;
   }
   .filters {
     margin-top: 10px;
-    margin-right: 95px;
   }
 }
 @media only screen and (max-width: 660px) {
   .Search__field {
     display: flex;
     align-items: center;
-    margin-left: 11rem;
     height: 30px;
   }
   .filters {
     margin-top: 10px;
-    margin-right: 95px;
   }
 }
 @media only screen and (max-width: 600px) {
   .Search__field {
     display: flex;
     align-items: center;
-    margin-left: 11rem;
     height: 30px;
   }
 
-  .Search__text {
-    margin-left: 70px;
-  }
   .filters {
     margin-top: 10px;
-    margin-right: 40px;
   }
 }
 
 @media only screen and (max-width: 400px) {
-  .Search__text {
-    margin-left: 80px;
-  }
   .Search__field {
-    margin-left: 110px;
     width: 230px;
     height: 30px;
   }
 
   .filters {
-    margin-right: -100px;
     margin-top: 5px;
   }
   .Search__text > h4 {
     font-weight: 900;
     font-size: 20px;
-    margin-left: 40px;
   }
 }


### PR DESCRIPTION
Instead of hardcoding a left margin to try and manually center the elements, use an `auto` margin so that it gets set automatically.